### PR TITLE
feat: add Drasl skin provider

### DIFF
--- a/common/src/main/java/net/lionarius/skinrestorer/SkinRestorer.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/SkinRestorer.java
@@ -88,6 +88,7 @@ public final class SkinRestorer {
         SkinRestorer.registerDefaultSkinProvider(MojangSkinProvider.PROVIDER_NAME, SkinProvider.MOJANG, SkinRestorer.getConfig().providersConfig().mojang());
         SkinRestorer.registerDefaultSkinProvider(ElyBySkinProvider.PROVIDER_NAME, SkinProvider.ELY_BY, SkinRestorer.getConfig().providersConfig().ely_by());
         SkinRestorer.registerDefaultSkinProvider(MineskinSkinProvider.PROVIDER_NAME, SkinProvider.MINESKIN, SkinRestorer.getConfig().providersConfig().mineskin());
+        SkinRestorer.registerDefaultSkinProvider(DraslSkinProvider.PROVIDER_NAME, SkinProvider.DRASL, SkinRestorer.getConfig().providersConfig().drasl());
         SkinRestorer.registerDefaultSkinProvider(CollectionSkinProvider.PROVIDER_NAME, SkinProvider.COLLECTION, SkinRestorer.getConfig().providersConfig().collection());
     }
     
@@ -107,6 +108,7 @@ public final class SkinRestorer {
         MojangSkinProvider.reload();
         ElyBySkinProvider.reload();
         MineskinSkinProvider.reload();
+        DraslSkinProvider.reload();
         CollectionSkinProvider.reload();
     }
     

--- a/common/src/main/java/net/lionarius/skinrestorer/config/FirstJoinSkinProvider.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/config/FirstJoinSkinProvider.java
@@ -2,6 +2,7 @@ package net.lionarius.skinrestorer.config;
 
 import com.google.gson.annotations.SerializedName;
 import net.lionarius.skinrestorer.skin.provider.CollectionSkinProvider;
+import net.lionarius.skinrestorer.skin.provider.DraslSkinProvider;
 import net.lionarius.skinrestorer.skin.provider.ElyBySkinProvider;
 import net.lionarius.skinrestorer.skin.provider.MojangSkinProvider;
 
@@ -10,6 +11,8 @@ public enum FirstJoinSkinProvider {
     MOJANG(MojangSkinProvider.PROVIDER_NAME),
     @SerializedName(value = "ELY.BY", alternate = {"ely.by", "ELY_BY", "ely_by"})
     ELY_BY(ElyBySkinProvider.PROVIDER_NAME),
+    @SerializedName(value = "DRASL", alternate = {"drasl"})
+    DRASL(DraslSkinProvider.PROVIDER_NAME),
     @SerializedName(value = "COLLECTION", alternate = {"collection"})
     COLLECTION(CollectionSkinProvider.PROVIDER_NAME);
     

--- a/common/src/main/java/net/lionarius/skinrestorer/config/provider/DraslProviderConfig.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/config/provider/DraslProviderConfig.java
@@ -10,7 +10,7 @@ public final class DraslProviderConfig extends BuiltInProviderConfig {
     private String url;
 
     public DraslProviderConfig() {
-        super(DraslSkinProvider.PROVIDER_NAME, DEFAULT_CACHE_VALUE);
+        super(DraslSkinProvider.PROVIDER_NAME, DEFAULT_CACHE_VALUE, false);
 
         this.url = "";
     }

--- a/common/src/main/java/net/lionarius/skinrestorer/config/provider/DraslProviderConfig.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/config/provider/DraslProviderConfig.java
@@ -1,0 +1,31 @@
+package net.lionarius.skinrestorer.config.provider;
+
+import net.lionarius.skinrestorer.SkinRestorer;
+import net.lionarius.skinrestorer.config.provider.CacheConfig;
+import net.lionarius.skinrestorer.skin.provider.DraslSkinProvider;
+
+public final class DraslProviderConfig extends BuiltInProviderConfig {
+    private static final CacheConfig DEFAULT_CACHE_VALUE = new CacheConfig(true, 60);
+    
+    private String url;
+
+    public DraslProviderConfig() {
+        super(DraslSkinProvider.PROVIDER_NAME, DEFAULT_CACHE_VALUE);
+
+        this.url = "";
+    }
+    
+    public String url() {
+        return url;
+    }
+
+    @Override
+    public void gsonPostProcess() {
+        super.validate(DraslSkinProvider.PROVIDER_NAME, DEFAULT_CACHE_VALUE);
+
+        if (this.url == null) {
+            SkinRestorer.LOGGER.warn("Drasl base URL not set");
+            this.url = "";
+        }
+    }
+}

--- a/common/src/main/java/net/lionarius/skinrestorer/config/provider/ProvidersConfig.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/config/provider/ProvidersConfig.java
@@ -9,18 +9,21 @@ public final class ProvidersConfig implements GsonPostProcessable {
             new MojangProviderConfig(),
             new ElyByProviderConfig(),
             new MineskinProviderConfig(),
+            new DraslProviderConfig(),
             new CollectionProviderConfig()
     );
     
     private MojangProviderConfig mojang;
     private ElyByProviderConfig ely_by;
     private MineskinProviderConfig mineskin;
+    private DraslProviderConfig drasl;
     private CollectionProviderConfig collection;
     
-    public ProvidersConfig(MojangProviderConfig mojang, ElyByProviderConfig ely_by, MineskinProviderConfig mineskin, CollectionProviderConfig collection) {
+    public ProvidersConfig(MojangProviderConfig mojang, ElyByProviderConfig ely_by, MineskinProviderConfig mineskin, DraslProviderConfig drasl, CollectionProviderConfig collection) {
         this.mojang = mojang;
         this.ely_by = ely_by;
         this.mineskin = mineskin;
+        this.drasl = drasl;
         this.collection = collection;
     }
     
@@ -36,6 +39,10 @@ public final class ProvidersConfig implements GsonPostProcessable {
         return this.mineskin;
     }
     
+    public DraslProviderConfig drasl() {
+        return this.drasl;
+    }
+
     public CollectionProviderConfig collection() {
         return this.collection;
     }
@@ -57,6 +64,11 @@ public final class ProvidersConfig implements GsonPostProcessable {
             this.mineskin = ProvidersConfig.DEFAULT.mineskin();
         }
         
+        if (this.drasl == null) {
+            SkinRestorer.LOGGER.warn("Drasl provider config is null, using default");
+            this.drasl = ProvidersConfig.DEFAULT.drasl();
+        }
+
         if (this.collection == null) {
             SkinRestorer.LOGGER.warn("Collection provider config is null, using default");
             this.collection = ProvidersConfig.DEFAULT.collection();

--- a/common/src/main/java/net/lionarius/skinrestorer/skin/provider/DraslSkinProvider.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/skin/provider/DraslSkinProvider.java
@@ -1,0 +1,197 @@
+package net.lionarius.skinrestorer.skin.provider;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.mojang.authlib.properties.Property;
+import com.mojang.authlib.yggdrasil.response.MinecraftProfilePropertiesResponse;
+import com.mojang.authlib.yggdrasil.response.NameAndId;
+import com.mojang.util.UndashedUuid;
+import it.unimi.dsi.fastutil.Pair;
+import net.lionarius.skinrestorer.SkinRestorer;
+import net.lionarius.skinrestorer.mineskin.Java11RequestHandler;
+import net.lionarius.skinrestorer.skin.SkinVariant;
+import net.lionarius.skinrestorer.skin.provider.SkinProvider;
+import net.lionarius.skinrestorer.util.JsonUtils;
+import net.lionarius.skinrestorer.util.PlayerUtils;
+import net.lionarius.skinrestorer.util.Result;
+import net.lionarius.skinrestorer.util.WebUtils;
+import net.minecraft.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.mineskin.MineSkinClient;
+import org.mineskin.data.Variant;
+import org.mineskin.data.Visibility;
+import org.mineskin.request.GenerateRequest;
+import org.mineskin.response.QueueResponse;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.UUID;
+import java.io.IOException;
+
+public final class DraslSkinProvider implements SkinProvider {
+    
+    public static final String PROVIDER_NAME = "drasl";
+    
+    private static MineSkinClient MINESKIN_CLIENT;
+    
+    private static LoadingCache<String, Optional<Property>> SKIN_CACHE;
+    
+    private static URI BASE_URL;
+    
+    public static void reload() {
+        var config = SkinRestorer.getConfig();
+        var mineskinApiKey = config.providersConfig().mineskin().apiKey();
+        var draslConfig = config.providersConfig().drasl();
+        var draslUrl = draslConfig.url();
+
+        if (draslUrl != null && !draslUrl.isEmpty()) {
+            try {
+                BASE_URL = new URI(draslUrl);
+            } catch (URISyntaxException e) {
+                SkinRestorer.LOGGER.warn("Invalid Drasl base URL: {}", draslUrl, e);
+            }
+        }
+
+        MINESKIN_CLIENT = MineSkinClient
+                .builder()
+                .userAgent(WebUtils.USER_AGENT)
+                .gson(JsonUtils.GSON)
+                .timeout((int) Duration.ofSeconds(config.requestTimeout()).toMillis())
+                .requestHandler((baseUrl, userAgent, apiKey, timeout, gson) -> new Java11RequestHandler(
+                        baseUrl,
+                        userAgent,
+                        apiKey,
+                        timeout,
+                        gson,
+                        SkinRestorer.getConfig().proxy().map(proxy -> new InetSocketAddress(proxy.host(), proxy.port())).orElse(null)
+                ))
+                .apiKey(mineskinApiKey.isEmpty() ? null : mineskinApiKey)
+                .build();
+        
+        createCache();
+    }
+    
+    private static void createCache() {
+        var config = SkinRestorer.getConfig().providersConfig().drasl();
+        var time = config.cache().enabled() ? config.cache().duration() : 0;
+        
+        SKIN_CACHE = CacheBuilder.newBuilder()
+                .expireAfterWrite(time, TimeUnit.SECONDS)
+                .build(new CacheLoader<>() {
+                    @Override
+                    public @NotNull Optional<Property> load(@NotNull String key) throws Exception {
+                        return DraslSkinProvider.loadSkin(key);
+                    }
+                });
+    }
+    
+    @Override
+    public String getArgumentName() {
+        return "username";
+    }
+    
+    @Override
+    public boolean hasVariantSupport() {
+        return true;
+    }
+    
+    @Override
+    public Result<Optional<Property>, Exception> fetchSkin(String username, SkinVariant variant) {
+        try {
+            if (!StringUtil.isValidPlayerName(username))
+                throw new IllegalArgumentException("invalid username");
+            
+            var usernameLowerCase = username.toLowerCase();
+            
+            return Result.success(SKIN_CACHE.get(username));
+        } catch (UncheckedExecutionException e) {
+            return Result.error((Exception) e.getCause());
+        } catch (Exception e) {
+            return Result.error(e);
+        }
+    }
+    
+    private static Optional<Property> loadSkin(String username) throws Exception {
+        var nameAndId = getProfile(username);
+        var profile = getProfileWithProperties(nameAndId.id());
+        var skin = PlayerUtils.getSkinUrl(profile);
+        
+        if (skin == null)
+            return Optional.empty();
+        
+        return DraslSkinProvider.signSkinUrl(skin.first(), skin.second());
+    }
+    
+    private static NameAndId getProfile(final String name) throws IOException {
+        if (BASE_URL == null)
+            throw new IllegalStateException("Drasl is not configured, check your config.");
+        
+        var request = HttpRequest.newBuilder()
+                .uri(DraslSkinProvider.BASE_URL
+                        .resolve("/minecraft/profile/lookup/name/")
+                        .resolve(name)
+                )
+                .GET()
+                .build();
+        
+        var response = WebUtils.executeRequest(request);
+        WebUtils.throwOnClientErrors(response);
+        
+        if (response.statusCode() != 200)
+            throw new IllegalArgumentException("no profile with name " + name);
+        
+        return JsonUtils.fromJson(response.body(), NameAndId.class);
+    }
+    
+    private static com.mojang.authlib.GameProfile getProfileWithProperties(UUID uuid) throws Exception {
+        if (BASE_URL == null)
+            throw new IllegalStateException("Drasl BASE_URL is not initialized. Make sure the Drasl provider is properly configured and loaded.");
+        
+        var request = HttpRequest.newBuilder()
+                .uri(DraslSkinProvider.BASE_URL
+                        .resolve("/session/minecraft/profile/")
+                        .resolve(uuid.toString().replace("-", ""))
+                )
+                .GET()
+                .build();
+        
+        var response = WebUtils.executeRequest(request);
+        WebUtils.throwOnClientErrors(response);
+        
+        if (response.statusCode() != 200)
+            throw new IllegalArgumentException("no profile with uuid " + uuid);
+        
+        return JsonUtils.fromJson(response.body(), MinecraftProfilePropertiesResponse.class).profile();
+    }
+    
+    private static Optional<Property> signSkinUrl(String textureUrl, SkinVariant variant) throws Exception {
+        var mineskinVariant = switch (variant) {
+            case CLASSIC -> Variant.CLASSIC;
+            case SLIM -> Variant.SLIM;
+        };
+        
+        var request = GenerateRequest.url(new URI(textureUrl))
+                .variant(mineskinVariant)
+                .name("skinrestorer-skin")
+                .visibility(Visibility.UNLISTED);
+        
+        var skin = MINESKIN_CLIENT.queue().submit(request)
+                .thenApply(QueueResponse::getJob)
+                .thenCompose(jobInfo -> jobInfo.waitForCompletion(MINESKIN_CLIENT))
+                .thenCompose(jobReference -> jobReference.getOrLoadSkin(MINESKIN_CLIENT))
+                .join();
+        
+        return Optional.of(new Property(
+                PlayerUtils.TEXTURES_KEY,
+                skin.texture().data().value(),
+                skin.texture().data().signature()
+        ));
+    }
+}

--- a/common/src/main/java/net/lionarius/skinrestorer/skin/provider/DraslSkinProvider.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/skin/provider/DraslSkinProvider.java
@@ -9,7 +9,6 @@ import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.yggdrasil.response.MinecraftProfilePropertiesResponse;
 import com.mojang.authlib.yggdrasil.response.NameAndId;
 import net.lionarius.skinrestorer.SkinRestorer;
-import net.lionarius.skinrestorer.mineskin.Java11RequestHandler;
 import net.lionarius.skinrestorer.skin.SkinVariant;
 import net.lionarius.skinrestorer.util.JsonUtils;
 import net.lionarius.skinrestorer.util.PlayerUtils;
@@ -17,17 +16,10 @@ import net.lionarius.skinrestorer.util.Result;
 import net.lionarius.skinrestorer.util.WebUtils;
 import net.minecraft.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
-import org.mineskin.MineSkinClient;
-import org.mineskin.data.Variant;
-import org.mineskin.data.Visibility;
-import org.mineskin.request.GenerateRequest;
-import org.mineskin.response.QueueResponse;
 
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpRequest;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.UUID;
@@ -37,8 +29,6 @@ public final class DraslSkinProvider implements SkinProvider {
     
     public static final String PROVIDER_NAME = "drasl";
     
-    private static MineSkinClient MINESKIN_CLIENT;
-    
     private static LoadingCache<String, Optional<Property>> SKIN_CACHE;
     private static Cache<String, Property> SIGNATURE_CACHE;
     
@@ -46,7 +36,6 @@ public final class DraslSkinProvider implements SkinProvider {
     
     public static void reload() {
         var config = SkinRestorer.getConfig();
-        var mineskinApiKey = config.providersConfig().mineskin().apiKey();
         var draslUrl = config.providersConfig().drasl().url();
 
         if (draslUrl != null && !draslUrl.isEmpty()) {
@@ -56,22 +45,6 @@ public final class DraslSkinProvider implements SkinProvider {
                 SkinRestorer.LOGGER.warn("Invalid Drasl base URL: {}", draslUrl, e);
             }
         }
-
-        MINESKIN_CLIENT = MineSkinClient
-                .builder()
-                .userAgent(WebUtils.USER_AGENT)
-                .gson(JsonUtils.GSON)
-                .timeout((int) Duration.ofSeconds(config.requestTimeout()).toMillis())
-                .requestHandler((baseUrl, userAgent, apiKey, timeout, gson) -> new Java11RequestHandler(
-                        baseUrl,
-                        userAgent,
-                        apiKey,
-                        timeout,
-                        gson,
-                        SkinRestorer.getConfig().proxy().map(proxy -> new InetSocketAddress(proxy.host(), proxy.port())).orElse(null)
-                ))
-                .apiKey(mineskinApiKey.isEmpty() ? null : mineskinApiKey)
-                .build();
         
         createCache();
     }
@@ -138,7 +111,7 @@ public final class DraslSkinProvider implements SkinProvider {
             return Optional.of(cachedSignature);
         }
         
-        var signed = DraslSkinProvider.signSkinUrl(textureUrl, variant);
+        var signed = MineskinSkinProvider.loadSkin(new URI(textureUrl), variant);
         signed.ifPresent(prop -> SIGNATURE_CACHE.put(textureUrl, prop));
         
         return signed;
@@ -181,29 +154,5 @@ public final class DraslSkinProvider implements SkinProvider {
             throw new IllegalArgumentException("no profile with uuid " + uuid);
         
         return JsonUtils.fromJson(response.body(), MinecraftProfilePropertiesResponse.class).profile();
-    }
-    
-    private static Optional<Property> signSkinUrl(String textureUrl, SkinVariant variant) throws Exception {
-        var mineskinVariant = switch (variant) {
-            case CLASSIC -> Variant.CLASSIC;
-            case SLIM -> Variant.SLIM;
-        };
-        
-        var request = GenerateRequest.url(new URI(textureUrl))
-                .variant(mineskinVariant)
-                .name("skinrestorer-skin")
-                .visibility(Visibility.UNLISTED);
-        
-        var skin = MINESKIN_CLIENT.queue().submit(request)
-                .thenApply(QueueResponse::getJob)
-                .thenCompose(jobInfo -> jobInfo.waitForCompletion(MINESKIN_CLIENT))
-                .thenCompose(jobReference -> jobReference.getOrLoadSkin(MINESKIN_CLIENT))
-                .join();
-        
-        return Optional.of(new Property(
-                PlayerUtils.TEXTURES_KEY,
-                skin.texture().data().value(),
-                skin.texture().data().signature()
-        ));
     }
 }

--- a/common/src/main/java/net/lionarius/skinrestorer/skin/provider/DraslSkinProvider.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/skin/provider/DraslSkinProvider.java
@@ -1,5 +1,6 @@
 package net.lionarius.skinrestorer.skin.provider;
 
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -7,12 +8,9 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.yggdrasil.response.MinecraftProfilePropertiesResponse;
 import com.mojang.authlib.yggdrasil.response.NameAndId;
-import com.mojang.util.UndashedUuid;
-import it.unimi.dsi.fastutil.Pair;
 import net.lionarius.skinrestorer.SkinRestorer;
 import net.lionarius.skinrestorer.mineskin.Java11RequestHandler;
 import net.lionarius.skinrestorer.skin.SkinVariant;
-import net.lionarius.skinrestorer.skin.provider.SkinProvider;
 import net.lionarius.skinrestorer.util.JsonUtils;
 import net.lionarius.skinrestorer.util.PlayerUtils;
 import net.lionarius.skinrestorer.util.Result;
@@ -42,14 +40,14 @@ public final class DraslSkinProvider implements SkinProvider {
     private static MineSkinClient MINESKIN_CLIENT;
     
     private static LoadingCache<String, Optional<Property>> SKIN_CACHE;
+    private static Cache<String, Property> SIGNATURE_CACHE;
     
     private static URI BASE_URL;
     
     public static void reload() {
         var config = SkinRestorer.getConfig();
         var mineskinApiKey = config.providersConfig().mineskin().apiKey();
-        var draslConfig = config.providersConfig().drasl();
-        var draslUrl = draslConfig.url();
+        var draslUrl = config.providersConfig().drasl().url();
 
         if (draslUrl != null && !draslUrl.isEmpty()) {
             try {
@@ -90,6 +88,11 @@ public final class DraslSkinProvider implements SkinProvider {
                         return DraslSkinProvider.loadSkin(key);
                     }
                 });
+        
+        SIGNATURE_CACHE = CacheBuilder.newBuilder()
+                .expireAfterAccess(24, TimeUnit.HOURS)
+                .maximumSize(1000)
+                .build();
     }
     
     @Override
@@ -110,7 +113,7 @@ public final class DraslSkinProvider implements SkinProvider {
             
             var usernameLowerCase = username.toLowerCase();
             
-            return Result.success(SKIN_CACHE.get(username));
+            return Result.success(SKIN_CACHE.get(usernameLowerCase));
         } catch (UncheckedExecutionException e) {
             return Result.error((Exception) e.getCause());
         } catch (Exception e) {
@@ -126,12 +129,24 @@ public final class DraslSkinProvider implements SkinProvider {
         if (skin == null)
             return Optional.empty();
         
-        return DraslSkinProvider.signSkinUrl(skin.first(), skin.second());
+        var textureUrl = skin.first();
+        var variant = skin.second();
+        
+        var cachedSignature = SIGNATURE_CACHE.getIfPresent(textureUrl);
+        
+        if (cachedSignature != null) {
+            return Optional.of(cachedSignature);
+        }
+        
+        var signed = DraslSkinProvider.signSkinUrl(textureUrl, variant);
+        signed.ifPresent(prop -> SIGNATURE_CACHE.put(textureUrl, prop));
+        
+        return signed;
     }
     
     private static NameAndId getProfile(final String name) throws IOException {
         if (BASE_URL == null)
-            throw new IllegalStateException("Drasl is not configured, check your config.");
+            throw new IllegalStateException("Drasl is not configured in this server.");
         
         var request = HttpRequest.newBuilder()
                 .uri(DraslSkinProvider.BASE_URL
@@ -151,9 +166,6 @@ public final class DraslSkinProvider implements SkinProvider {
     }
     
     private static com.mojang.authlib.GameProfile getProfileWithProperties(UUID uuid) throws Exception {
-        if (BASE_URL == null)
-            throw new IllegalStateException("Drasl BASE_URL is not initialized. Make sure the Drasl provider is properly configured and loaded.");
-        
         var request = HttpRequest.newBuilder()
                 .uri(DraslSkinProvider.BASE_URL
                         .resolve("/session/minecraft/profile/")

--- a/common/src/main/java/net/lionarius/skinrestorer/skin/provider/SkinProvider.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/skin/provider/SkinProvider.java
@@ -13,6 +13,7 @@ public interface SkinProvider {
     MojangSkinProvider MOJANG = new MojangSkinProvider();
     ElyBySkinProvider ELY_BY = new ElyBySkinProvider();
     MineskinSkinProvider MINESKIN = new MineskinSkinProvider();
+    DraslSkinProvider DRASL = new DraslSkinProvider();
     CollectionSkinProvider COLLECTION = new CollectionSkinProvider();
     SkinShuffleSkinProvider SKIN_SHUFFLE = new SkinShuffleSkinProvider();
     
@@ -21,6 +22,7 @@ public interface SkinProvider {
             MojangSkinProvider.PROVIDER_NAME,
             ElyBySkinProvider.PROVIDER_NAME,
             MineskinSkinProvider.PROVIDER_NAME,
+            DraslSkinProvider.PROVIDER_NAME,
             CollectionSkinProvider.PROVIDER_NAME,
             SkinShuffleSkinProvider.PROVIDER_NAME
     );

--- a/common/src/main/java/net/lionarius/skinrestorer/util/PlayerUtils.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/util/PlayerUtils.java
@@ -7,7 +7,9 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
 import com.mojang.authlib.yggdrasil.response.MinecraftProfilePropertiesResponse;
+import it.unimi.dsi.fastutil.Pair;
 import net.lionarius.skinrestorer.mixin.ChunkMapAccessor;
+import net.lionarius.skinrestorer.skin.SkinVariant;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.level.ChunkMap;
@@ -106,6 +108,37 @@ public final class PlayerUtils {
     
     public static Property getPlayerSkin(GameProfile profile) {
         return Iterables.getFirst(profile.properties().get(TEXTURES_KEY), null);
+    }
+    
+    public static Pair<String, SkinVariant> getSkinUrl(GameProfile profile) {
+        var skin = getPlayerSkin(profile);
+        if (skin == null)
+            return null;
+        
+        var textureJson = JsonUtils.skinPropertyToJson(skin);
+        if (textureJson == null || !textureJson.has("textures"))
+            return null;
+        
+        var textures = textureJson.getAsJsonObject("textures");
+        if (!textures.has("SKIN"))
+            return null;
+        
+        var skinTexture = textures.getAsJsonObject("SKIN");
+        if (!skinTexture.has("url"))
+            return null;
+        
+        String url = skinTexture.get("url").getAsString();
+        SkinVariant variant = SkinVariant.CLASSIC;
+
+        if (skinTexture.has("metadata")) {
+            var metadata = skinTexture.getAsJsonObject("metadata");
+            if (metadata.has("model")) {
+                String model = metadata.get("model").getAsString();
+                variant = model.equals("slim") ? SkinVariant.SLIM : SkinVariant.CLASSIC;
+            }
+        }
+        
+        return Pair.of(url, variant);
     }
     
     public static GameProfile applyRestoredSkin(GameProfile profile, Property skin) {


### PR DESCRIPTION
This PR adds Drasl support by using the MineSkin client already used in the web provider. This allows Mojang accounts to see Drasl skins and viceversa without requiring the client to have any mods. 
I also added cache for signed textures to prevent unnecesary calls to mineskin, valid for 24 hours.

Note that i don't know much about Java so if i did something wrong or you want me to change something, please tell me.
