### PR TITLE
Complete migration to Minecraft 26.1 and Java 25 (Fabric-focused)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     // see https://fabricmc.net/develop/ for new versions
-    id 'fabric-loom' version '1.13-SNAPSHOT' apply false
-    // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '2.0.+' apply false
-    // see https://files.minecraftforge.net/net/minecraftforge/gradle/ForgeGradle/ for new versions
-    id 'net.minecraftforge.gradle' version '6.0.+' apply false
-    id 'org.parchmentmc.librarian.forgegradle' version '1.+' apply false
+    id 'net.fabricmc.fabric-loom' version '1.15.5' apply false
 
     id 'org.spongepowered.mixin' version '0.7-SNAPSHOT' apply false
 

--- a/buildSrc/src/main/groovy/multiloader-publish.gradle
+++ b/buildSrc/src/main/groovy/multiloader-publish.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 publishMods {
-    file = project.layout.buildDirectory.file("libs/${project.archivesBaseName}-${project.version}.jar").map { it.asFile }.getOrNull()
+    file = project.layout.buildDirectory.file("libs/${base.archivesName.get()}-${project.version}.jar").map { it.asFile }.getOrNull()
 
     modLoaders.add(project.name)
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,15 +1,13 @@
 plugins {
     id 'multiloader-common'
 
-    id 'fabric-loom'
+    id 'net.fabricmc.fabric-loom'
 }
 
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
-    mappings loom.layered {
-        officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-${parchment_minecraft}:${parchment_version}@zip")
-    }
+    // No mappings needed for 26.1+
+    
     compileOnly group: 'org.spongepowered', name: 'mixin', version: '0.8.5'
 
     implementation("org.mineskin:java-client:${mineskin_client_version}")

--- a/common/src/main/resources/skinrestorer.accesswidener
+++ b/common/src/main/resources/skinrestorer.accesswidener
@@ -1,1 +1,1 @@
-accessWidener v2 named
+accessWidener v2 official

--- a/common/src/main/resources/skinrestorer.mixins.json
+++ b/common/src/main/resources/skinrestorer.mixins.json
@@ -2,7 +2,7 @@
     "required": true,
     "minVersion": "0.8",
     "package": "net.lionarius.skinrestorer.mixin",
-    "compatibilityLevel": "JAVA_17",
+    "compatibilityLevel": "JAVA_25",
     "priority": 1100,
     "refmap": "${mod_id}.refmap.json",
     "mixins": [

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,20 +1,18 @@
 plugins {
     id 'multiloader-loader'
 
-    id 'fabric-loom'
+    id 'net.fabricmc.fabric-loom'
 
     id 'multiloader-publish'
 }
 
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
-    mappings loom.layered {
-        officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-${parchment_minecraft}:${parchment_version}@zip")
-    }
-    modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
+    // No mappings needed for 26.1+
+    
+    implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
 
-    modCompileOnly "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}"
+    compileOnly "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}"
 
     include implementation("org.mineskin:java-client:${mineskin_client_version}")
 }

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,6 +1,6 @@
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_loader_version=0.15.0
-fabric_api_version=0.139.4+1.21.11
+fabric_loader_version=0.18.4
+fabric_api_version=0.144.3+26.1
 
 optional_dependencies=fabric-api
 additional_modloaders=quilt

--- a/fabric/src/main/java/net/lionarius/skinrestorer/fabric/compat/skinshuffle/SkinShuffleCompatibility.java
+++ b/fabric/src/main/java/net/lionarius/skinrestorer/fabric/compat/skinshuffle/SkinShuffleCompatibility.java
@@ -20,11 +20,11 @@ public final class SkinShuffleCompatibility {
             return;
         }
 
-        PayloadTypeRegistry.playS2C()
+        PayloadTypeRegistry.clientboundPlay()
                 .register(SkinShuffleHandshakePayload.PACKET_ID, SkinShuffleHandshakePayload.PACKET_CODEC);
-        PayloadTypeRegistry.playC2S()
+        PayloadTypeRegistry.serverboundPlay()
                 .register(SkinShuffleSkinRefreshV1Payload.PACKET_ID, SkinShuffleSkinRefreshV1Payload.PACKET_CODEC);
-        PayloadTypeRegistry.playC2S()
+        PayloadTypeRegistry.serverboundPlay()
                 .register(SkinShuffleSkinRefreshV2Payload.PACKET_ID, SkinShuffleSkinRefreshV2Payload.PACKET_CODEC);
 
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 # Project
 group=net.lionarius
-java_version=21
+java_version=25
 
 # Common
-minecraft_version=1.21.11
-minecraft_version_list=1.21.11
-minecraft_version_range=[1.21.11, 1.22)
+minecraft_version=26.1
+minecraft_version_list=26.1
+minecraft_version_range=[26.1, 27)
 mod_id=skinrestorer
 mod_name=SkinRestorer
 mod_version=2.7.0
@@ -19,10 +19,6 @@ description=A server-side mod for managing skins.
 
 # Dependencies
 mineskin_client_version=3.2.1-SNAPSHOT
-
-# ParchmentMC mappings, see https://parchmentmc.org/docs/getting-started#choose-a-version for new versions
-parchment_minecraft=1.21.11
-parchment_version=2025.12.20
 
 # Publishing
 curseforge_id=443823

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,46 +17,12 @@ pluginManagement {
         exclusiveContent {
             forRepository {
                 maven {
-                    name = 'Forge'
-                    url = 'https://maven.minecraftforge.net'
-                }
-            }
-            filter {
-                includeGroupAndSubgroups('net.minecraftforge')
-            }
-        }
-        exclusiveContent {
-            forRepository {
-                maven {
-                    name = 'NeoForge'
-                    url = 'https://maven.neoforged.net/releases'
-                }
-            }
-            filter {
-                includeGroupAndSubgroups('net.neoforged')
-                includeGroupAndSubgroups('codechicken')
-            }
-        }
-        exclusiveContent {
-            forRepository {
-                maven {
                     name = 'Sponge'
                     url = 'https://repo.spongepowered.org/repository/maven-public'
                 }
             }
             filter {
                 includeGroupAndSubgroups('org.spongepowered')
-            }
-        }
-        exclusiveContent {
-            forRepository {
-                maven {
-                    name = 'ParchmentMC'
-                    url = 'https://maven.parchmentmc.org'
-                }
-            }
-            filter {
-                includeGroupAndSubgroups('org.parchmentmc')
             }
         }
     }
@@ -66,9 +32,8 @@ plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }
 
-// This should match the folder name of the project, or else IDEA may complain (see https://youtrack.jetbrains.com/issue/IDEA-317606)
 rootProject.name = 'skin-restorer'
 include('common')
 include('fabric')
-include('forge')
-include('neoforge')
+// include('forge') // Temporarily disabled for Gradle 9.4.0 (Minecraft 26.1) support
+// include('neoforge') // Temporarily disabled for Gradle 9.4.0 (Minecraft 26.1) support


### PR DESCRIPTION
This PR migrates the project to support Minecraft 26.1 (the first unobfuscated version) and upgrades the development environment to Java 25 and Gradle 9.4.0. Due to current limitations in third-party Gradle plugins for Forge and NeoForge, this update focuses on stabilizing the Fabric and Common modules.