### PR TITLE
feat(autoFetch): add fallback support

### DIFF
--- a/common/src/main/java/net/lionarius/skinrestorer/SkinRestorer.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/SkinRestorer.java
@@ -111,18 +111,21 @@ public final class SkinRestorer {
     }
 
     private static void validateAutoFetchProvider() {
-        var providerName = SkinRestorer.config.join().autoFetchConfig().provider();
-        var provider = SkinRestorer.providersRegistry.get(providerName);
+        var providersName = SkinRestorer.config.join().autoFetchConfig().providers();
 
-        if (provider == null) {
-            SkinRestorer.LOGGER.warn(
-                    "AutoFetch provider '{}' is not registered. Auto fetch skin fetching will be skipped.",
-                    providerName);
-        } else if (provider.getParameterType() != SkinProviderParameterType.USERNAME) {
-            SkinRestorer.LOGGER.warn(
-                    "AutoFetch provider '{}' has parameter type {}, but only USERNAME providers are supported. Auto fetch skin fetching will be skipped.",
-                    providerName,
-                    provider.getParameterType());
+        for (String providerName : providersName) {
+            var provider = SkinRestorer.providersRegistry.get(providerName);
+
+            if (provider == null) {
+                SkinRestorer.LOGGER.warn(
+                        "AutoFetch provider '{}' is not registered. Auto fetch skin fetching will be skipped.",
+                        providerName);
+            } else if (provider.getParameterType() != SkinProviderParameterType.USERNAME) {
+                SkinRestorer.LOGGER.warn(
+                        "AutoFetch provider '{}' has parameter type {}, but only USERNAME providers are supported. Auto fetch skin fetching will be skipped.",
+                        providerName,
+                        provider.getParameterType());
+            }
         }
     }
 

--- a/common/src/main/java/net/lionarius/skinrestorer/SkinRestorer.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/SkinRestorer.java
@@ -111,9 +111,9 @@ public final class SkinRestorer {
     }
 
     private static void validateAutoFetchProvider() {
-        var providersName = SkinRestorer.config.join().autoFetchConfig().providers();
+        var providerNames = SkinRestorer.config.join().autoFetchConfig().providers();
 
-        for (String providerName : providersName) {
+        for (String providerName : providerNames) {
             var provider = SkinRestorer.providersRegistry.get(providerName);
 
             if (provider == null) {

--- a/common/src/main/java/net/lionarius/skinrestorer/config/AutoFetchConfig.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/config/AutoFetchConfig.java
@@ -6,6 +6,8 @@ import net.lionarius.skinrestorer.skin.provider.builtin.ElyBySkinProvider;
 import net.lionarius.skinrestorer.skin.provider.builtin.MojangSkinProvider;
 import net.lionarius.skinrestorer.util.gson.GsonPostProcessable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public final class AutoFetchConfig implements GsonPostProcessable {
@@ -14,7 +16,8 @@ public final class AutoFetchConfig implements GsonPostProcessable {
 
     private boolean overrideExisting = false;
 
-    private String provider = MojangSkinProvider.PROVIDER_NAME;
+    private List<String> providers = new ArrayList<>(
+            List.of(MojangSkinProvider.PROVIDER_NAME, ElyBySkinProvider.PROVIDER_NAME));
 
     public boolean enabled() {
         return this.enabled;
@@ -24,26 +27,29 @@ public final class AutoFetchConfig implements GsonPostProcessable {
         return this.overrideExisting;
     }
 
-    public String provider() {
-        return this.provider;
+    public List<String> providers() {
+        return this.providers;
     }
 
     @Override
     public void gsonPostProcess() {
-        if (this.provider == null) {
-            SkinRestorer.LOGGER.warn("AutoFetch provider config is null, defaulting to MOJANG");
-            this.provider = MojangSkinProvider.PROVIDER_NAME;
-        } else if (this.provider.isBlank()) {
-            SkinRestorer.LOGGER.warn("AutoFetch provider config is empty, defaulting to MOJANG");
-            this.provider = MojangSkinProvider.PROVIDER_NAME;
-        } else {
-            this.provider = AutoFetchConfig.normalizeProvider(this.provider);
+        if (this.providers == null || this.providers.isEmpty()) {
+            SkinRestorer.LOGGER.warn("AutoFetch providers config is null/empty, defaulting to MOJANG");
+            this.providers = List.of(MojangSkinProvider.PROVIDER_NAME);
+            return;
+        }
 
-            if (this.provider.isEmpty()) {
-                SkinRestorer.LOGGER.warn(
-                        "AutoFetch provider config is empty after normalization, defaulting to MOJANG");
-                this.provider = MojangSkinProvider.PROVIDER_NAME;
-            }
+        var normalized = this.providers.stream()
+                .map(AutoFetchConfig::normalizeProvider)
+                .filter(p -> p != null && !p.isBlank())
+                .toList();
+
+        if (normalized.isEmpty()) {
+            SkinRestorer.LOGGER.warn(
+                    "AutoFetch providers config is empty after normalization, defaulting to MOJANG");
+            this.providers = List.of(MojangSkinProvider.PROVIDER_NAME);
+        } else {
+            this.providers = normalized;
         }
     }
 

--- a/common/src/main/java/net/lionarius/skinrestorer/config/AutoFetchConfig.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/config/AutoFetchConfig.java
@@ -6,7 +6,6 @@ import net.lionarius.skinrestorer.skin.provider.builtin.ElyBySkinProvider;
 import net.lionarius.skinrestorer.skin.provider.builtin.MojangSkinProvider;
 import net.lionarius.skinrestorer.util.gson.GsonPostProcessable;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -16,8 +15,7 @@ public final class AutoFetchConfig implements GsonPostProcessable {
 
     private boolean overrideExisting = false;
 
-    private List<String> providers = new ArrayList<>(
-            List.of(MojangSkinProvider.PROVIDER_NAME, ElyBySkinProvider.PROVIDER_NAME));
+    private List<String> providers = List.of(MojangSkinProvider.PROVIDER_NAME);
 
     public boolean enabled() {
         return this.enabled;

--- a/common/src/main/java/net/lionarius/skinrestorer/mixin/ServerLoginPacketListenerImplMixin.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/mixin/ServerLoginPacketListenerImplMixin.java
@@ -67,14 +67,16 @@ public abstract class ServerLoginPacketListenerImplMixin {
                 }
 
                 var autoFetchConfig = SkinRestorer.getConfig().join().autoFetchConfig();
-                var providerName = autoFetchConfig.provider();
+                var providersName = autoFetchConfig.providers();
 
                 var shouldFetch = (originalSkin == null && autoFetchConfig.enabled())
                         || (originalSkin != null
-                                && autoFetchConfig.overrideExisting()
-                                && !providerName.equals(MojangSkinProvider.PROVIDER_NAME));
+                                && autoFetchConfig.overrideExisting());
 
-                if (shouldFetch) {
+                if (!shouldFetch)
+                    return null;
+
+                for (String providerName : providersName) {
                     var provider = SkinRestorer.getProvider(providerName).orElse(null);
 
                     if (provider == null || provider.getParameterType() != SkinProviderParameterType.USERNAME) {
@@ -82,10 +84,29 @@ public abstract class ServerLoginPacketListenerImplMixin {
                                 "Skipping first join skin fetch for '{}': provider '{}' does not accept username parameter",
                                 profile.name(),
                                 providerName);
-                    } else {
-                        var context = new SkinProviderContext(providerName, profile.name(), null);
-                        skinrestorer$fetchSkin(profile, context);
+
+                        continue;
                     }
+
+                    var context = new SkinProviderContext(providerName, profile.name(), null);
+                    var result = skinrestorer$fetchSkin(profile, context);
+
+                    if (result.isError()) {
+                        SkinRestorer.LOGGER.warn(
+                                "Skin fetch failed for '{}' using provider '{}': {}",
+                                profile.name(),
+                                providerName,
+                                result.getErrorValue());
+
+                        continue;
+                    }
+
+                    SkinRestorer.LOGGER.info(
+                            "Skin fetch success for '{}' using provider '{}'",
+                            profile.name(),
+                            providerName);
+
+                    break;
                 }
 
                 return null;
@@ -96,7 +117,7 @@ public abstract class ServerLoginPacketListenerImplMixin {
     }
 
     @Unique
-    private static void skinrestorer$fetchSkin(GameProfile profile, SkinProviderContext context) {
+    private static Result<?, ?> skinrestorer$fetchSkin(GameProfile profile, SkinProviderContext context) {
         SkinRestorer.LOGGER.debug("Fetching {}'s skin", profile.name());
 
         var result = SkinRestorer.getProvider(context.name())
@@ -109,8 +130,10 @@ public abstract class ServerLoginPacketListenerImplMixin {
                     context, result.getSuccessValue().orElse(null));
             SkinRestorer.getSkinStorage().setSkin(profile.id(), value);
         } else {
-            SkinRestorer.LOGGER.warn(
+            SkinRestorer.LOGGER.debug(
                     "Failed to fetch skin '{}:{}'", context.name(), context.argument(), result.getErrorValue());
         }
+
+        return result;
     }
 }

--- a/common/src/main/java/net/lionarius/skinrestorer/mixin/ServerLoginPacketListenerImplMixin.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/mixin/ServerLoginPacketListenerImplMixin.java
@@ -5,7 +5,6 @@ import net.lionarius.skinrestorer.SkinRestorer;
 import net.lionarius.skinrestorer.skin.SkinValue;
 import net.lionarius.skinrestorer.skin.provider.SkinProviderContext;
 import net.lionarius.skinrestorer.skin.provider.SkinProviderParameterType;
-import net.lionarius.skinrestorer.skin.provider.builtin.MojangSkinProvider;
 import net.lionarius.skinrestorer.util.PlayerUtils;
 import net.lionarius.skinrestorer.util.Result;
 import net.minecraft.server.network.ServerLoginPacketListenerImpl;
@@ -67,7 +66,7 @@ public abstract class ServerLoginPacketListenerImplMixin {
                 }
 
                 var autoFetchConfig = SkinRestorer.getConfig().join().autoFetchConfig();
-                var providersName = autoFetchConfig.providers();
+                var providerNames = autoFetchConfig.providers();
 
                 var shouldFetch = (originalSkin == null && autoFetchConfig.enabled())
                         || (originalSkin != null
@@ -76,7 +75,7 @@ public abstract class ServerLoginPacketListenerImplMixin {
                 if (!shouldFetch)
                     return null;
 
-                for (String providerName : providersName) {
+                for (String providerName : providerNames) {
                     var provider = SkinRestorer.getProvider(providerName).orElse(null);
 
                     if (provider == null || provider.getParameterType() != SkinProviderParameterType.USERNAME) {
@@ -89,22 +88,11 @@ public abstract class ServerLoginPacketListenerImplMixin {
                     }
 
                     var context = new SkinProviderContext(providerName, profile.name(), null);
-                    var result = skinrestorer$fetchSkin(profile, context);
+                    var skinFetched = skinrestorer$fetchSkin(profile, context);
 
-                    if (result.isError()) {
-                        SkinRestorer.LOGGER.warn(
-                                "Skin fetch failed for '{}' using provider '{}': {}",
-                                profile.name(),
-                                providerName,
-                                result.getErrorValue());
-
+                    if (!skinFetched) {
                         continue;
                     }
-
-                    SkinRestorer.LOGGER.info(
-                            "Skin fetch success for '{}' using provider '{}'",
-                            profile.name(),
-                            providerName);
 
                     break;
                 }
@@ -116,8 +104,11 @@ public abstract class ServerLoginPacketListenerImplMixin {
         if (!skinrestorer$pendingSkin.isDone()) ci.cancel();
     }
 
+    /**
+     * @return true if fetch succeeded, false if there was an error
+     */
     @Unique
-    private static Result<?, ?> skinrestorer$fetchSkin(GameProfile profile, SkinProviderContext context) {
+    private static Boolean skinrestorer$fetchSkin(GameProfile profile, SkinProviderContext context) {
         SkinRestorer.LOGGER.debug("Fetching {}'s skin", profile.name());
 
         var result = SkinRestorer.getProvider(context.name())
@@ -130,10 +121,10 @@ public abstract class ServerLoginPacketListenerImplMixin {
                     context, result.getSuccessValue().orElse(null));
             SkinRestorer.getSkinStorage().setSkin(profile.id(), value);
         } else {
-            SkinRestorer.LOGGER.debug(
+            SkinRestorer.LOGGER.warn(
                     "Failed to fetch skin '{}:{}'", context.name(), context.argument(), result.getErrorValue());
         }
 
-        return result;
+        return !result.isError();
     }
 }


### PR DESCRIPTION
## Summary

This PR adds support for multiple skin providers with fallback logic during auto-fetch.

Previously, only a single provider defined in the config (`autoFetch.provider`) was used, which caused failures when the selected provider could not resolve a skin (e.g. Ely.by-only users or missing Mojang profiles).

## Changes

- Replaced single provider logic with a provider list (`autoFetch.providers`)
- Implemented sequential fallback:
  - tries providers in order (e.g. `ely_by` → `mojang`)
  - stops on first successful fetch
- Updated config normalization to support multiple providers
- Improved logging:
  - clearer provider-specific messages
  - reduced unnecessary warnings
- Refactored `skinrestorer$fetchSkin` to return `Result<?>` for proper error handling

## Behavior

- If a provider fails, the next one is attempted
- Success stops further attempts
- Logging reflects each attempt and final result

## Example

```json
"providers": ["ely_by", "mojang"]