### PR TITLE
feat: add UUID targeting support to skin commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
 
 allprojects {
     repositories {
+        mavenCentral()
         exclusiveContent {
             forRepository {
                 maven {

--- a/common/src/main/java/net/lionarius/skinrestorer/command/SkinCommand.java
+++ b/common/src/main/java/net/lionarius/skinrestorer/command/SkinCommand.java
@@ -23,6 +23,7 @@ import net.minecraft.server.level.ServerPlayer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -38,8 +39,12 @@ public final class SkinCommand {
                 .then(buildSetSubcommand("clear", SkinValue.EMPTY::toProviderContext))
                 .then(literal("reset")
                         .executes(context -> resetSubcommand(context.getSource()))
-                        .then(makeTargetsArgument(
-                                (context, profiles) -> resetSubcommand(context.getSource(), profiles, true))))
+                        .then(literal("targets")
+                                .then(makeTargetsArgument(
+                                        (context, profiles) -> resetSubcommand(context.getSource(), profiles, true))))
+                        .then(literal("uuid")
+                                .then(makeUUIDTargetsArgument(
+                                        (context, profiles) -> resetSubcommand(context.getSource(), profiles, true)))))
                 .then(literal("refresh").executes(context -> refreshSubcommand(context.getSource())));
 
         var set = literal("set");
@@ -202,8 +207,12 @@ public final class SkinCommand {
                     ArgumentBuilder<CommandSourceStack, T> argument,
                     Function<CommandContext<CommandSourceStack>, SkinProviderContext> provider) {
         return argument.executes(context -> setSubcommand(context.getSource(), provider.apply(context)))
-                .then(makeTargetsArgument((context, targets) ->
-                        setSubcommand(context.getSource(), targets, provider.apply(context), true)));
+                .then(literal("targets")
+                        .then(makeTargetsArgument((context, targets) ->
+                                setSubcommand(context.getSource(), targets, provider.apply(context), true))))
+                .then(literal("uuid")
+                        .then(makeUUIDTargetsArgument((context, targets) ->
+                                setSubcommand(context.getSource(), targets, provider.apply(context), true))));
     }
 
     private static RequiredArgumentBuilder<CommandSourceStack, GameProfileArgument.Result> makeTargetsArgument(
@@ -211,5 +220,31 @@ public final class SkinCommand {
         return argument("targets", GameProfileArgument.gameProfile())
                 .requires(source -> source.hasPermission(2))
                 .executes(context -> consumer.apply(context, GameProfileArgument.getGameProfiles(context, "targets")));
+    }
+
+    private static RequiredArgumentBuilder<CommandSourceStack, String> makeUUIDTargetsArgument(
+            BiFunction<CommandContext<CommandSourceStack>, Collection<GameProfile>, Integer> consumer) {
+        return argument("uuid", StringArgumentType.string())
+                .requires(source -> source.hasPermission(2))
+                .executes(context -> {
+                    var input = StringArgumentType.getString(context, "uuid");
+                    try {
+                        var uuid = UUID.fromString(input);
+                        var server = context.getSource().getServer();
+                        var player = server.getPlayerList().getPlayer(uuid);
+                        GameProfile profile;
+                        if (player != null) {
+                            profile = player.getGameProfile();
+                        } else {
+                            profile = server.getProfileCache().get(uuid).orElse(new GameProfile(uuid, null));
+                        }
+                        return consumer.apply(context, Collections.singleton(profile));
+                    } catch (IllegalArgumentException e) {
+                        context.getSource()
+                                .sendFailure(Translation.translatableWithFallback(
+                                        Translation.COMMAND_SKIN_FAILED_KEY, input));
+                        return 0;
+                    }
+                });
     }
 }

--- a/neoforge/gradle.properties
+++ b/neoforge/gradle.properties
@@ -1,3 +1,3 @@
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
-neoforge_version=21.0.0-beta
+neoforge_version=21.1.248
 neoforge_loader_version_range=[4,)


### PR DESCRIPTION
## Changes
Adds `targets` and `uuid` keyword subcommands

## Commands
Before: `/skin set <provider> <value> <selector/name>`
After:
- `/skin set <provider> <value> targets <selector/name>`
- `/skin set <provider> <value> uuid <uuid>`
- `/skin reset targets <selector/name>`
- `/skin reset uuid <uuid>`
- `/skin clear targets <selector/name>`
- `/skin clear uuid <uuid>`


## Why
`GameProfileArgument` only resolves players that are online or in the 
server's user cache. UUIDs are unresolvable via the existing `targets` 
argument. This is a problem for server admins managing skins for offline 
or renamed players, since usernames can change but UUIDs never do.

## Build fix
Also bumps NeoForge version from `21.0.0-beta` to `21.1.248` (latest stable 
for MC 1.21.1) and adds `mavenCentral()` to `allprojects.repositories`. 
The beta version had a broken transitive dependency (`log4j:2.11.+` via 
`net.minecraftforge:unsafe:0.2.0`) causing the build to fail entirely.